### PR TITLE
Added option to pull images and added dependencies in setup

### DIFF
--- a/descpipe/pipeline.py
+++ b/descpipe/pipeline.py
@@ -53,10 +53,10 @@ class Pipeline:
                 path = run_path
                 break
         else:
-            raise PipelineError("""No Stage called {} was found - needs to be in one 
+            raise PipelineError("""No Stage called {} was found - needs to be in one
                 of the images directories and contain Dockerfile, run.py""".format(name))
 
-        # We want to load a module based on a python.  The python people keep changing how to do this in obscure 
+        # We want to load a module based on a python.  The python people keep changing how to do this in obscure
         # ways.  This one is deprecated but works back in python 3.4 which is what centos 7 can provide.
         loader = importlib.machinery.SourceFileLoader(name, path)
         module = loader.load_module()

--- a/descpipe/ui.py
+++ b/descpipe/ui.py
@@ -20,6 +20,9 @@ parser_local.add_argument('pipe_file', type=str, help='Input pipeline file to bu
 parser_local = subparsers.add_parser('push', help='Run "make push" in the pipe directories')
 parser_local.add_argument('pipe_file', type=str, help='Input pipeline file to push')
 
+parser_local = subparsers.add_parser('pull', help='Run "make pull" in the pipe directories')
+parser_local.add_argument('pipe_file', type=str, help='Input pipeline file to pull')
+
 parser_local = subparsers.add_parser('nersc', help='Make a bash script to the pipeline under shifter')
 parser_local.add_argument('pipe_file', type=str, help='Input pipeline file to generate a script for')
 parser_local.add_argument('script_file', type=str, help='Output bash script to generate')
@@ -45,6 +48,11 @@ def build(args):
 def push(args):
     pipeline=Pipeline(args.pipe_file)
     pipeline.push()
+
+@task
+def pull(args):
+    pipeline=Pipeline(args.pipe_file)
+    pipeline.pull()
 
 @task
 def nersc(args):
@@ -79,9 +87,8 @@ def main():
         return 1
     else:
         task = tasks.get(args.task, unknown)
-        return task(args)        
+        return task(args)
 
 if __name__ == '__main__':
     status = main()
     sys.exit(status)
-

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,5 @@ setup(name='descpipe',
       version='1.1',
       scripts=['bin/descpipe'],
       packages=['descpipe', 'descpipe.launcher'],
+      install_requires=['pyyaml','py-dag']
       )


### PR DESCRIPTION
This pull request makes it easier to pull images (especially for nersc) by adding the command to the ui. Also includes dependencies (py-dag, pyyaml) in the setup.py so that the whole package can automatically be installed with a simple pip command:
```
pip3 install git+git://github.com/EiffL/descpipe.git --user
```